### PR TITLE
Enzhu/use table level ip

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
@@ -59,13 +59,13 @@ public class InstancePartitionsUtils {
   /**
    * Fetches the instance partitions from Helix property store if it exists, or computes it for backward-compatibility.
    */
-  public static InstancePartitions fetchOrComputeInstancePartitions(HelixManager helixManager, TableConfig tableConfig,
+  public static InstancePartitions fetchOrComputeInstancePartitionsForSegmentAssignment(HelixManager helixManager, TableConfig tableConfig,
       InstancePartitionsType instancePartitionsType) {
     String tableNameWithType = tableConfig.getTableName();
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
     // If table has pre-configured table-level instance partitions
-    if (shouldFetchPreConfiguredInstancePartitions(tableConfig, instancePartitionsType)) {
+    if (shouldFetchPreConfiguredTenantInstancePartitions(tableConfig, instancePartitionsType)) {
       return fetchInstancePartitionsWithRename(helixManager.getHelixPropertyStore(),
           tableConfig.getInstancePartitionsMap().get(instancePartitionsType),
           instancePartitionsType.getInstancePartitionsName(rawTableName));
@@ -194,7 +194,7 @@ public class InstancePartitionsUtils {
         });
   }
 
-  public static boolean shouldFetchPreConfiguredInstancePartitions(TableConfig tableConfig,
+  public static boolean shouldFetchPreConfiguredTenantInstancePartitions(TableConfig tableConfig,
       InstancePartitionsType instancePartitionsType) {
     return TableConfigUtils.hasPreConfiguredInstancePartitions(tableConfig, instancePartitionsType) &&
         !InstanceAssignmentConfigUtils.isMirrorServerSetAssignment(tableConfig, instancePartitionsType);

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
@@ -65,8 +65,7 @@ public class InstancePartitionsUtils {
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
     // If table has pre-configured table-level instance partitions
-    if (TableConfigUtils.hasPreConfiguredInstancePartitions(tableConfig, instancePartitionsType) &&
-        !InstanceAssignmentConfigUtils.isMirrorServerSetAssignment(tableConfig, instancePartitionsType)) {
+    if (shouldFetchPreConfiguredInstancePartitions(tableConfig, instancePartitionsType)) {
       return fetchInstancePartitionsWithRename(helixManager.getHelixPropertyStore(),
           tableConfig.getInstancePartitionsMap().get(instancePartitionsType),
           instancePartitionsType.getInstancePartitionsName(rawTableName));
@@ -193,5 +192,11 @@ public class InstancePartitionsUtils {
         .forEach(instancePartition -> {
           removeInstancePartitions(propertyStore, instancePartition.getInstancePartitionsName());
         });
+  }
+
+  public static boolean shouldFetchPreConfiguredInstancePartitions(TableConfig tableConfig,
+      InstancePartitionsType instancePartitionsType) {
+    return TableConfigUtils.hasPreConfiguredInstancePartitions(tableConfig, instancePartitionsType) &&
+        !InstanceAssignmentConfigUtils.isMirrorServerSetAssignment(tableConfig, instancePartitionsType);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitionsUtils.java
@@ -64,8 +64,9 @@ public class InstancePartitionsUtils {
     String tableNameWithType = tableConfig.getTableName();
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
-    // If table has pre-configured instance partitions.
-    if (TableConfigUtils.hasPreConfiguredInstancePartitions(tableConfig, instancePartitionsType)) {
+    // If table has pre-configured table-level instance partitions
+    if (TableConfigUtils.hasPreConfiguredInstancePartitions(tableConfig, instancePartitionsType) &&
+        !InstanceAssignmentConfigUtils.isMirrorServerSetAssignment(tableConfig, instancePartitionsType)) {
       return fetchInstancePartitionsWithRename(helixManager.getHelixPropertyStore(),
           tableConfig.getInstancePartitionsMap().get(instancePartitionsType),
           instancePartitionsType.getInstancePartitionsName(rawTableName));

--- a/pinot-common/src/test/java/org/apache/pinot/common/assignment/InstancePartitionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/assignment/InstancePartitionsUtilsTest.java
@@ -18,25 +18,25 @@ import org.testng.annotations.Test;
 public class InstancePartitionsUtilsTest {
 
   @Test
-  public void testFetchPreConfiguredInstancePartitions() {
+  public void testShouldFetchPreConfiguredTenantInstancePartitions() {
     Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap = new HashMap<>();
     instanceAssignmentConfigMap.put(InstancePartitionsType.OFFLINE.name(),
         getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
         .setInstanceAssignmentConfigMap(instanceAssignmentConfigMap).build();
 
-    Assert.assertTrue(InstancePartitionsUtils.shouldFetchPreConfiguredInstancePartitions(tableConfig, InstancePartitionsType.OFFLINE));
+    Assert.assertTrue(InstancePartitionsUtils.shouldFetchPreConfiguredTenantInstancePartitions(tableConfig, InstancePartitionsType.OFFLINE));
   }
 
   @Test
-  public void testFetchPreConfiguredInstancePartitionsMirrorServerSet() {
+  public void testPreConfiguredTenantInstancePartitionsMirrorServerSet() {
     Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap = new HashMap<>();
     instanceAssignmentConfigMap.put(InstancePartitionsType.OFFLINE.name(),
         getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.MIRROR_SERVER_SET_PARTITION_SELECTOR));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
         .setInstanceAssignmentConfigMap(instanceAssignmentConfigMap).build();
 
-    Assert.assertFalse(InstancePartitionsUtils.shouldFetchPreConfiguredInstancePartitions(tableConfig, InstancePartitionsType.OFFLINE));
+    Assert.assertFalse(InstancePartitionsUtils.shouldFetchPreConfiguredTenantInstancePartitions(tableConfig, InstancePartitionsType.OFFLINE));
   }
 
   private static InstanceAssignmentConfig getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector

--- a/pinot-common/src/test/java/org/apache/pinot/common/assignment/InstancePartitionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/assignment/InstancePartitionsUtilsTest.java
@@ -1,0 +1,56 @@
+package org.apache.pinot.common.assignment;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
+import org.apache.pinot.spi.config.table.assignment.InstanceConstraintConfig;
+import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
+import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class InstancePartitionsUtilsTest {
+
+  @Test
+  public void testFetchPreConfiguredInstancePartitions() {
+    Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap = new HashMap<>();
+    instanceAssignmentConfigMap.put(InstancePartitionsType.OFFLINE.name(),
+        getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setInstanceAssignmentConfigMap(instanceAssignmentConfigMap).build();
+
+    Assert.assertTrue(InstancePartitionsUtils.shouldFetchPreConfiguredInstancePartitions(tableConfig, InstancePartitionsType.OFFLINE));
+  }
+
+  @Test
+  public void testFetchPreConfiguredInstancePartitionsMirrorServerSet() {
+    Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap = new HashMap<>();
+    instanceAssignmentConfigMap.put(InstancePartitionsType.OFFLINE.name(),
+        getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.MIRROR_SERVER_SET_PARTITION_SELECTOR));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setInstanceAssignmentConfigMap(instanceAssignmentConfigMap).build();
+
+    Assert.assertFalse(InstancePartitionsUtils.shouldFetchPreConfiguredInstancePartitions(tableConfig, InstancePartitionsType.OFFLINE));
+  }
+
+  private static InstanceAssignmentConfig getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector
+      partitionSelector) {
+    InstanceTagPoolConfig instanceTagPoolConfig =
+        new InstanceTagPoolConfig("tag", true, 1, null);
+    List<String> constraints = new ArrayList<>();
+    constraints.add("constraints1");
+    InstanceConstraintConfig instanceConstraintConfig = new InstanceConstraintConfig(constraints);
+    InstanceReplicaGroupPartitionConfig instanceReplicaGroupPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 1, 1,
+            1, 1, 1, true,
+            null);
+    return new InstanceAssignmentConfig(instanceTagPoolConfig, instanceConstraintConfig,
+        instanceReplicaGroupPartitionConfig, partitionSelector.name(), false);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2489,14 +2489,14 @@ public class PinotHelixResourceManager {
       TableConfig tableConfig) {
     if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
       return Collections.singletonMap(InstancePartitionsType.OFFLINE,
-          InstancePartitionsUtils.fetchOrComputeInstancePartitions(_helixZkManager, tableConfig,
+          InstancePartitionsUtils.fetchOrComputeInstancePartitionsForSegmentAssignment(_helixZkManager, tableConfig,
               InstancePartitionsType.OFFLINE));
     }
     if (tableConfig.getUpsertMode() != UpsertConfig.Mode.NONE) {
       // In an upsert enabled LLC realtime table, all segments of the same partition are collocated on the same server
       // -- consuming or completed. So it is fine to use CONSUMING as the InstancePartitionsType.
       return Collections.singletonMap(InstancePartitionsType.CONSUMING,
-          InstancePartitionsUtils.fetchOrComputeInstancePartitions(_helixZkManager, tableConfig,
+          InstancePartitionsUtils.fetchOrComputeInstancePartitionsForSegmentAssignment(_helixZkManager, tableConfig,
               InstancePartitionsType.CONSUMING));
     }
     // for non-upsert realtime tables, if COMPLETED instance partitions is available or tag override for

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -369,7 +369,7 @@ public class PinotLLCRealtimeSegmentManager {
   @VisibleForTesting
   InstancePartitions getConsumingInstancePartitions(TableConfig tableConfig) {
     try {
-      return InstancePartitionsUtils.fetchOrComputeInstancePartitions(_helixManager, tableConfig,
+      return InstancePartitionsUtils.fetchOrComputeInstancePartitionsForSegmentAssignment(_helixManager, tableConfig,
           InstancePartitionsType.CONSUMING);
     } catch (Exception e) {
       _controllerMetrics.addMeteredTableValue(tableConfig.getTableName(), ControllerMeter.LLC_ZOOKEEPER_FETCH_FAILURES,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -670,7 +670,7 @@ public class TableRebalancer {
     } else {
       LOGGER.info("Fetching/computing {} instance partitions for table: {}", instancePartitionsType, tableNameWithType);
       return Pair.of(
-          InstancePartitionsUtils.fetchOrComputeInstancePartitions(_helixManager, tableConfig, instancePartitionsType),
+          InstancePartitionsUtils.fetchOrComputeInstancePartitionsForSegmentAssignment(_helixManager, tableConfig, instancePartitionsType),
           true);
     }
   }


### PR DESCRIPTION
This pull requests fixes a bug when we use pre-configured instance partitions, we should check both if table has pre-configured instance partitions and if the table is not a mirror server set assignment.

Unit tests is included for the new method `shouldFetchPreConfiguredInstancePartitions` in `InstancePartitionsUtils.java`
